### PR TITLE
Add Codecov coverage reporting in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,38 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  test:
+    name: Test and Coverage
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+          cache: true
+
+      - name: Download dependencies
+        run: go mod download
+
+      - name: Run tests with coverage
+        working-directory: graph
+        run: TESTING=true go test -v -covermode=atomic -coverprofile=coverage.out .
+
+      - name: Upload coverage report to Codecov
+        if: always()
+        uses: codecov/codecov-action@v5
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          files: ./graph/coverage.out
+          flags: unittests
+          fail_ci_if_error: false

--- a/README.md
+++ b/README.md
@@ -1,4 +1,6 @@
 # gratheon / swarm-api
+[![codecov](https://codecov.io/gh/Gratheon/swarm-api/graph/badge.svg?token=ZOJQ9HEHU3)](https://codecov.io/gh/Gratheon/swarm-api)
+
 Main monolith service to manage beehive data.
 
 


### PR DESCRIPTION
## Summary
- add a GitHub Actions CI workflow for `swarm-api`
- run Go tests in `graph/` with coverage output
- upload coverage report to Codecov using `CODECOV_TOKEN`
- add Codecov badge to README

## Notes
- secret env var for Codecov is already configured at org/repo level